### PR TITLE
Remove console.log from master

### DIFF
--- a/src/directives/autostart.js
+++ b/src/directives/autostart.js
@@ -42,7 +42,6 @@ export default async(el, binding) => {
         };
     }
 
-    console.log(binding);
     if (binding.arg === 'hints') {
         el.__introjsAutoHints = true;
     }


### PR DESCRIPTION
We should keep console.logs only on dev versions. In production version, we should not expose anything.