### PR TITLE
[Docs]: change webpack.ProvidePlugin code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ As this plugin relies on global `introJs` variable, webpack's should provide it:
     plugins: [
         new webpack.ProvidePlugin({
             // other modules
-            introJs: ['intro.js', 'introJs']
+            introJs: ['intro.js']
         })
     ]
 }


### PR DESCRIPTION
To prevent the error: "Deprecated: please use require("intro.js") directly, instead of the introJs method of the function"